### PR TITLE
Patch to remove Git checking on remote server

### DIFF
--- a/src/cuisine_sweet/ensure/git.py
+++ b/src/cuisine_sweet/ensure/git.py
@@ -58,8 +58,6 @@ def rsync(repo_url, repo_dir, refspec='master', home='.', base_dir='git', local_
     clone_basepath_remote = os.path.join(home, base_dir)
     cuisine.dir_ensure(clone_basepath_remote)
 
-    cuisine.command_ensure('git', package='git')
-
     # prepare history (for recovery)
     hist = git.GitHistory()
     if save_history:


### PR DESCRIPTION
Hi Sir,

Please patch cuisine_sweet to not check for git on the remote server as it is not needed since we are transferring via rsync. 

Thanks!
